### PR TITLE
Ignoring also css files from subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ yarn-debug.log*
 yarn-error.log*
 
 src/*.css
+src/*/*.css


### PR DESCRIPTION
Subdirectories also should ignore css.

All css files should not be added in project at the end.